### PR TITLE
Removing Sandblocks-Cpp from Baseline, since the package doesn't exist

### DIFF
--- a/packages/BaselineOfSBTreeSitter/BaselineOfSBTreeSitter.class.st
+++ b/packages/BaselineOfSBTreeSitter/BaselineOfSBTreeSitter.class.st
@@ -95,7 +95,6 @@ BaselineOfSBTreeSitter >> baseline: spec [
 			package: 'Sandblocks-Regex' with: [spec requires: #('Sandblocks-TreeSitter')];
 			package: 'Sandblocks-Json' with: [spec requires: #('Sandblocks-TreeSitter')];
 			package: 'Sandblocks-C' with: [spec requires: #('Sandblocks-TreeSitter')];
-			package: 'Sandblocks-Cpp' with: [spec requires: #('Sandblocks-TreeSitter')];
 			package: 'Sandblocks-Vhdl' with: [spec requires: #('Sandblocks-TreeSitter')];
 			package: 'Sandblocks-TSSmalltalk' with: [spec requires: #('Sandblocks-TreeSitter')];
 			package: 'Sandblocks-Bash' with: [spec requires: #('Sandblocks-TreeSitter')];
@@ -108,7 +107,7 @@ BaselineOfSBTreeSitter >> baseline: spec [
 		
 		spec
 			group: 'default'
-			with: #('Sandblocks-TreeSitter' 'Sandblocks-Javascript' 'Sandblocks-Python' 'Sandblocks-Regex' 'Sandblocks-Json' 'Sandblocks-C' 'Sandblocks-Cpp' 'Sandblocks-Vhdl' 'Sandblocks-Bash' 'Sandblocks-Clojure' 'Sandblocks-TSSmalltalk' 'Sandblocks-Typescript' 'Sandblocks-Matplotlib' 'Sandblocks-RequestsTool' 'Sandblocks-Kotlin' 'Sandblocks-GDScript')]
+			with: #('Sandblocks-TreeSitter' 'Sandblocks-Javascript' 'Sandblocks-Python' 'Sandblocks-Regex' 'Sandblocks-Json' 'Sandblocks-C' 'Sandblocks-Vhdl' 'Sandblocks-Bash' 'Sandblocks-Clojure' 'Sandblocks-TSSmalltalk' 'Sandblocks-Typescript' 'Sandblocks-Matplotlib' 'Sandblocks-RequestsTool' 'Sandblocks-Kotlin' 'Sandblocks-GDScript')]
 ]
 
 { #category : #baseline }


### PR DESCRIPTION
This is a quick fix for Issue #2. 
  
It's probably the case that the `Sandblocks-Cpp` package was meant to be included in [this commit](https://github.com/hpi-swa-lab/sb-tree-sitter/commit/5c6cd58df63de0e21cf1809d44dfdc876d5caf43) (I think?), but it wasn't and its presence in the baseline prevents correct installation at this time.
  
My solution was simply to remove references to `Sandblocks-Cpp` from the baseline altogether for the moment.